### PR TITLE
fix for semistandard 6.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,6 @@ function acetate (options) {
   });
 
   return site;
-};
+}
 
 module.exports = acetate;

--- a/lib/mixins/logger.js
+++ b/lib/mixins/logger.js
@@ -57,7 +57,7 @@ module.exports = function (acetate) {
     if (print) {
       process.stdout.write(text + '\n');
     }
-  };
+  }
 
   return {
     time: time,

--- a/lib/mixins/nunjucks.js
+++ b/lib/mixins/nunjucks.js
@@ -125,7 +125,7 @@ module.exports = function (acetate) {
     }
 
     environment.addExtension(name, new CustomBlock());
-  };
+  }
 
   function filter (name, fn) {
     var wrapped = _.bind(function (value) {
@@ -140,11 +140,11 @@ module.exports = function (acetate) {
     }, this);
 
     environment.addFilter(name, wrapped);
-  };
+  }
 
   function global (key, value) {
     environment.addGlobal(key, value);
-  };
+  }
 
   block('highlight', function (context, body, lang) {
     var code = body;

--- a/lib/mixins/watcher.js
+++ b/lib/mixins/watcher.js
@@ -18,7 +18,7 @@ module.exports = function (acetate) {
     });
 
     acetate.emit('watcher:start');
-  };
+  }
 
   function changed (filepath) {
     acetate.info('watcher', '%s changed', filepath.replace(process.cwd() + path.sep, ''));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,7 +21,7 @@ function utils (options) {
       lineNo: lineNo,
       colNo: colNo
     };
-  };
+  }
 
   function formatException (error) {
     var e = parseException(error);


### PR DESCRIPTION
There are two new rules in `semistandard` 6.0.0 coming:
>* [no-extra-semi](http://eslint.org/docs/rules/no-extra-semi) - This rule is aimed at eliminating extra unnecessary semicolons. While not technically an error, extra semicolons can be a source of confusion when reading code.

>* [semi-spacing](http://eslint.org/docs/rules/semi-spacing) - Disallow a space before semicolons and force a space after them.

`semistandard` is linting this repository as part of its tests, and we found some lint errors when running these new rules.

This PR will fix the issues, which are all just `no-extra-semi` errors.

Note that `semistandard` 6.0.0 is not yet published as the latest version on npm, but if you want to install it locally to test, use `npm install -g semistandard@next`. It will be another day or two before `semistandard` is is pushed as latest.

