### PR TITLE
63

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -55,20 +55,29 @@ const argv = require('yargs')
   .describe('log', 'log levels: debug|info|warn|silent')
 
   // input option
-  .default('input', 'src')
-  .describe('input', 'source folder to read pages from')
-  .alias('i', 'input')
+  .option('input', {
+    alias: 'i',
+    describe: 'source folder to read pages from',
+    default: 'build',
+    global: true
+  })
 
   // output option
-  .default('output', 'build')
-  .describe('output', 'folder where pages will be built')
-  .alias('o', 'output')
+  .option('output', {
+    alias: 'o',
+    describe: 'folder where pages will be built',
+    default: 'build',
+    global: true
+  })
 
   // config file option
-  .default('config', 'acetate.config.js')
-  .describe('config', 'path to config file')
-  .alias('c', 'config')
-  .normalize('config')
+  .option('config', {
+    alias: 'c',
+    describe: 'path to config file',
+    default: 'acetate.config.js',
+    global: true,
+    normalize: true
+  })
 
   // http-cert option
   .describe('https-cert', 'enable https on the dev server with Browsersync certs')

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -98,11 +98,15 @@ function run () {
     });
   }
 
+  const root = path.dirname(path.resolve(argv.config));
+  const configPath = path.join(process.cwd(), argv.config);
+  const relativeConfig = path.relative(root, configPath);
+
   const acetate = new Acetate({
-    config: argv.config,
+    config: relativeConfig,
     sourceDir: argv.input,
     outDir: argv.output,
-    root: path.dirname(path.resolve(argv.config)),
+    root: root,
     logLevel: argv.log,
     args: argv
   });

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "normalize-newline": "^2.0.0",
     "normalize-url": "^1.5.2",
     "nunjucks": "^2.4.2",
-    "pretty-hrtime": "^1.0.2"
+    "pretty-hrtime": "^1.0.2",
+    "yargs": "^6.5.0"
   },
   "devDependencies": {
     "ava": "^0.15.1",


### PR DESCRIPTION
@patrickarlt couple acetate fixes that I need to build doc.

- adds yargs as an explicit dependency (not sure how this was working before)
- uses the newer yargs option syntax
- adds `global: true` to options that apply to `build`, `serve`, and `watch` (this should fix https://github.com/patrickarlt/acetate/issues/63)
- fix loading of config file when building acetate inside a subfolder. 

If you used acetate to build a site with a file tree like this:

```
package.json
docs
  - src
  - build
  - acetate.config.js
```

Using the following command:

```
acetate build --config docs/acetate.config.js
```

Up until now you'd get an error where it couldn't find `docs/docs/acetate.config.js`. `cli.js` now parses the root folder using the same logic as before, but sends Acetate a relative path for the config file.
