### PR TITLE
Fix title message for not-found.html template

### DIFF
--- a/lib/templates/not-found.html
+++ b/lib/templates/not-found.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Acetate Error | {{error.message}}</title>
+  <title>Acetate Error | Page Not Found</title>
   <style>
     #acetate-root {
       position: fixed;


### PR DESCRIPTION
Fixes title message showing up as `Acetate Error | {{error.message}}` and the title now matches the message in the body.