### PR TITLE
pass through browserSync startPath as a CLI option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -61,6 +61,13 @@ const argv = require("yargs")
     "https",
     "enable https on the dev server with built-in Browsersync certs"
   )
+  // startPath option
+  .boolean("startPath")
+  .default("startPath", "")
+  .describe(
+    "startPath",
+    "Open the browser window at URL: startPath=\"/folder/\""
+  )
   // log option
   .default("log", "debug")
   .describe("log", "log levels: debug|info|warn|silent")
@@ -99,6 +106,7 @@ const argv = require("yargs")
 
 const action = argv._.shift();
 let https;
+let startPath;
 
 if (argv.https) {
   https = argv.https;
@@ -109,6 +117,10 @@ if (argv.httpsCert && argv.httpsKey) {
     key: path.resolve(process.cwd(), argv.httpsKey),
     cert: path.resolve(process.cwd(), argv.httpsCert)
   };
+}
+
+if (argv.startPath) {
+  startPath = argv.startPath;
 }
 
 function run() {
@@ -134,7 +146,8 @@ function run() {
   switch (action) {
     case "server":
       server(acetate, {
-        https
+        https,
+        startPath
       });
       break;
 


### PR DESCRIPTION
adding [`startPath`](https://browsersync.io/docs/options#option-startPath) as a CLI option would help arcgis-rest-js use the command line to launch acetate's built in server.

if there's a way to set this in `acetate.config.js` instead, all the better.